### PR TITLE
Reference correct bedrock image tag in NlqEcsBedrockStack.yaml

### DIFF
--- a/cloudformation/NlqEcsBedrockStack.yaml
+++ b/cloudformation/NlqEcsBedrockStack.yaml
@@ -50,7 +50,7 @@ Parameters:
 
   ECRImageTag:
     Type: String
-    Default: "1.0.5-bedrock"
+    Default: "1.0.0-bedrock"
     Description: The name of the ECR Image tag to use with ECS/Fargate.
 
   TaskName:


### PR DESCRIPTION
Change CloudFormation parameter for ECSImageTag in Bedrock ECS stack to match the docker image build instructions/script.

*Issue #, if available:*
#46 

*Description of changes:*
Update Bedrock ECS stack to refer to the same ECS Image Tag that is in the build scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
